### PR TITLE
Manually shutdown okhttp because the server may shutdown by itself (e.g. with a /stop command)

### DIFF
--- a/minestom/src/main/java/net/buycraft/plugin/minestom/BuycraftPlugin.java
+++ b/minestom/src/main/java/net/buycraft/plugin/minestom/BuycraftPlugin.java
@@ -163,10 +163,15 @@ public class BuycraftPlugin extends Extension {
         if (completedCommandsTask != null) {
             completedCommandsTask.flush();
         }
-        // manually shutdown okhttp because the server may shutdown by itself (e.g. with a /stop command)
+        // manually shutdown okhttp because the server may shut down by itself (e.g. with a /stop command)
         this.httpClient.dispatcher().executorService().shutdown();
         this.httpClient.connectionPool().evictAll();
-        this.httpClient.cache().close();
+        try {
+            //noinspection ConstantConditions
+            this.httpClient.cache().close();
+        } catch (IOException e) {
+            MinecraftServer.LOGGER.error("Can't close cache", e);
+        } catch (NullPointerException ignore) {}
     }
 
     public BuyCraftAPI getApiClient() {

--- a/minestom/src/main/java/net/buycraft/plugin/minestom/BuycraftPlugin.java
+++ b/minestom/src/main/java/net/buycraft/plugin/minestom/BuycraftPlugin.java
@@ -163,6 +163,10 @@ public class BuycraftPlugin extends Extension {
         if (completedCommandsTask != null) {
             completedCommandsTask.flush();
         }
+        // manually shutdown okhttp because the server may shutdown by itself (e.g. with a /stop command)
+        this.httpClient.dispatcher().executorService().shutdown();
+        this.httpClient.connectionPool().evictAll();
+        this.httpClient.cache().close();
     }
 
     public BuyCraftAPI getApiClient() {


### PR DESCRIPTION
Hello, I have a /stop command calling among other `MinecraftServer#stopCleanly()`, which is calling `Extension#terminate()`. The problem is that the server never stops because of BuyCraft not shutting down its okhttp thread pools, and this is what I fixed here.